### PR TITLE
Feature pass remaining command line args to python code

### DIFF
--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -2129,8 +2129,33 @@ def objects_from_svg_file(file, keep_layers=False):
 class SimpleInkscapeScripting(inkex.EffectExtension):
     'Help the user create Inkscape objects with a simple API.'
 
+    def filename_arg(self, name):
+        """Existing file to read or option used in script arguments"""
+        if name == "-":
+            return None  # filename is set to None to read stdin
+        return inkex.utils.filename_arg(name)
+
+    def reconfigure_input_file_argument(self, pars):
+        target_action = None
+        for action in pars._actions:
+            if 'input_file' == action.dest:
+                target_action = action
+                break
+
+        target_action.container._remove_action(target_action)
+        pars.add_argument(
+            "input_file",
+            nargs="?",
+            metavar="INPUT_FILE",
+            type=self.filename_arg,
+            help="Filename of the input file (default is stdin). Filename can be `-` for stdin",
+            default=None,
+        )
+
     def add_arguments(self, pars):
         'Process program parameters passed in from the UI.'
+
+        self.reconfigure_input_file_argument(pars)
         pars.add_argument('--tab', dest='tab',
                           help='The selected UI tab when OK was pressed')
         pars.add_argument('--program', type=str,

--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -2137,6 +2137,8 @@ class SimpleInkscapeScripting(inkex.EffectExtension):
                           help='Python code to execute')
         pars.add_argument('--py-source', type=str,
                           help='Python source file to execute')
+        pars.add_argument('rest_args', nargs="*",
+                          help='Rest Arguments for passing Python code')
 
     def find_attach_point(self):
         '''Return a suitable point in the SVG XML tree at which to attach
@@ -2179,6 +2181,7 @@ class SimpleInkscapeScripting(inkex.EffectExtension):
         sis_globals['height'] = _simple_top.height
         sis_globals['guides'] = _simple_top.get_existing_guides()
         sis_globals['print'] = _debug_print
+        sis_globals['rest_args'] = self.options.rest_args
         try:
             # Inkscape 1.2+
             convert_unit = self.svg.viewport_to_unit

--- a/tests/test_simple_inkscape_scripting.py
+++ b/tests/test_simple_inkscape_scripting.py
@@ -2,6 +2,9 @@ from simpinkscr.simple_inkscape_scripting import SimpleInkscapeScripting
 from simpinkscr.svg_to_simp_ink_script import SvgToPythonScript
 from inkex.tester import ComparisonMixin, InkscapeExtensionTestMixin, TestCase
 from inkex.tester.filters import CompareOrderIndependentStyle
+from unittest.mock import patch
+from io import StringIO
+
 
 class SimpInkScrBasicTest(ComparisonMixin, InkscapeExtensionTestMixin, TestCase):
     # Indicate how testing should be performed.
@@ -222,3 +225,23 @@ class SimpInkScrOutputBasicTest(ComparisonMixin, TestCase):
     effect_class = SvgToPythonScript
     compare_file = 'svg/shapes.svg'
     comparisons = [()]
+
+
+class SimpInkScrCmdlineArgsTest(TestCase):
+    effect_class = SimpleInkscapeScripting
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_without_rest_args(self, _stderr):
+        args = ["--program", "print(rest_args)", self.empty_svg]
+        effect = self.effect_class()
+        effect.run(args)
+        output = _stderr.getvalue().rstrip()
+        assert "[]" == output
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_with_rest_args(self, _stderr):
+        args = ["--program", "print(rest_args)", self.empty_svg, "--", "-a", "1", "--b", "2", "3"]
+        effect = self.effect_class()
+        effect.run(args)
+        output = _stderr.getvalue().rstrip()
+        assert "['-a', '1', '--b', '2', '3']" == output


### PR DESCRIPTION
## Purpose
This pull request proposes a change to allow for passing extra arguments to the Python code in the 'Simple Inkscape Scripting' command line usage. (See https://github.com/spakin/SimpInkScr/issues/4 for more information.)

## Proposed Change
The proposed change is to add a new command line argument, rest_args, which would be exposed as a global variable in the Python code. This would allow users to pass additional arguments to the Python code, such as positional arguments or arguments beginning with "-".

```python
pars.add_argument('rest_args', nargs="*", help='Rest Arguments for passing Python code')

# ...snip...

sis_globals['rest_args'] = self.options.rest_args
```

## Usage example

```python
# add positional args
% simple_inkscape_scripting.py --program "print('rest_args: ', rest_args)" --output output.svg input.svg data.json
rest_args: ['data.json']

# add positional arguments that begining with -
% simple_inkscape_scripting.py  --program "print('rest_args: ', rest_args)" --output output.svg input.svg -- --option1 --option2 data.json
rest_args: ['--option1', '--option2', 'data.json']
```

## Potential issues

This change misidentifies INPUT_FILE as the first element of rest_args when the argument INPUT_FILE is omitted.

## Workaround

As a remedy, when using the standard input, make it possible to specify - for the argument INPUT_FILE.

```python
    def filename_arg(self, name):
        """Existing file to read or option used in script arguments"""
        if name == "-":
            return None  # filename is set to None to read stdin
        return inkex.utils.filename_arg(name)

    def reconfigure_input_file_argument(self, pars):
        target_action = None
        for action in pars._actions:
            if 'input_file' == action.dest:
                target_action = action
                break

        target_action.container._remove_action(target_action)
        pars.add_argument(
            "input_file",
            nargs="?",
            metavar="INPUT_FILE",
            type=self.filename_arg,
            help="Filename of the input file (default is stdin). Filename can be `-` for stdin",
            default=None,
```

---

`Simple Inkscape Scripting` is incredibly helpful, thank you for creating it!
