### PR TITLE
Implement the label parameter for the guide lines.

### DIFF
--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -1569,7 +1569,7 @@ class SimplePathEffect(SVGOutputMixin):
 class SimpleGuide(SVGOutputMixin):
     'Represent an Inkscape guide.'
 
-    def __init__(self, pos, angle, color=None):
+    def __init__(self, pos, angle, color=None, label=None):
         'Create a guide at a given position and angle.'
         # pos is stored in user coordinates, and angle is clockwise.
         # In contrast, inkex expects pos to be relative to a
@@ -1578,6 +1578,7 @@ class SimpleGuide(SVGOutputMixin):
         self._inkscape_obj = inkex.elements.Guide()
         self._move_to_wrapper(pos, angle)
         self.color = color
+        self.label = label
 
     def get_inkex_object(self):
         "Return the guide's underlying inkex object."
@@ -1625,6 +1626,20 @@ class SimpleGuide(SVGOutputMixin):
         else:
             self._inkscape_obj.set('inkscape:color', str(c))
         self._color = c
+
+    @property
+    def label(self):
+        "Return the guide's label."
+        return self._label
+
+    @label.setter
+    def label(self, l):
+        "Change the guide's label."
+        if l is None:
+            self._inkscape_obj.attrib.pop('inkscape:label', None)
+        else:
+            self._inkscape_obj.set('inkscape:label', str(l))
+        self._label = l
 
     @classmethod
     def _from_inkex_object(self, iobj):
@@ -3042,9 +3057,9 @@ def all_shapes():
     return root_shapes + layer_shapes
 
 
-def guide(pos, angle, color=None):
+def guide(pos, angle, color=None, label=None):
     'Create a new guide without adding it to the document.'
-    return SimpleGuide(pos, angle, color)
+    return SimpleGuide(pos, angle, color, label)
 
 
 def page(name=None, pos=None, size=None):

--- a/simpinkscr/svg_to_simp_ink_script.py
+++ b/simpinkscr/svg_to_simp_ink_script.py
@@ -1023,14 +1023,13 @@ class SvgToPythonScript(inkex.OutputExtension):
             extra = ', color=%s' % repr(color)
 
         # Determine if we were given a label.
-        extra_label = ''
         label = node.get('inkscape:label')
         if label is not None:
-            extra_label = ', label=%s' % repr(label)
+            extra += ', label=%s' % repr(label)
 
         # Generate code and wrap it in a statement.
         code = ['guides.append(guide((%.10g, %.10g), %.10g%s))' %
-                (pos[0], pos[1], angle, extra, extra_label)]
+                (pos[0], pos[1], angle, extra)]
         return self.Statement(code, node.get_id(), [])
 
     def convert_all_shapes(self):

--- a/simpinkscr/svg_to_simp_ink_script.py
+++ b/simpinkscr/svg_to_simp_ink_script.py
@@ -1022,9 +1022,15 @@ class SvgToPythonScript(inkex.OutputExtension):
         if color is not None:
             extra = ', color=%s' % repr(color)
 
+        # Determine if we were given a label.
+        extra_label = ''
+        label = node.get('inkscape:label')
+        if label is not None:
+            extra_label = ', label=%s' % repr(label)
+
         # Generate code and wrap it in a statement.
         code = ['guides.append(guide((%.10g, %.10g), %.10g%s))' %
-                (pos[0], pos[1], angle, extra)]
+                (pos[0], pos[1], angle, extra, extra_label)]
         return self.Statement(code, node.get_id(), [])
 
     def convert_all_shapes(self):


### PR DESCRIPTION
Add _label_ as an optional parameter for the guide lines.
If you find the idea good, I can also update the Quick Reference Guide.

**Example**

Running `guides.extend([guide((20, 20), 180, label='Page margin')])` would output this:

![image](https://github.com/spakin/SimpInkScr/assets/80247117/93888561-3ca7-4f6b-9b88-af029de2d1c5)
