### PR TITLE
Fixing and improving the removal of imports when using VSCode

### DIFF
--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -3724,7 +3724,8 @@ from inkex.paths import curve, horz, move, quadratic, smooth, \
 
         # Remove an unnecessary import that may be introduced when
         # running from Visual Studio Code.
-        code.replace("from simpinkscr import *", "")
+        pattern = r"^(import (inkex|simpinkscr)|(from (inkex|simpinkscr) import.*))\r*\n*"
+        code = re.sub(pattern, "", code, flags=re.MULTILINE+re.IGNORECASE)
 
         # Launch the user's script.
         try:

--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -3724,7 +3724,7 @@ from inkex.paths import curve, horz, move, quadratic, smooth, \
 
         # Remove an unnecessary import that may be introduced when
         # running from Visual Studio Code.
-        pattern = r"^[ \t]*(import\s+(inkex|simpinkscr).*|(from\s+(inkex|simpinkscr)\s+import).*)[\r\n]?"
+        pattern = r"^[ \t]*(import\s+(inkex|simpinkscr).*|(from\s+(inkex|simpinkscr)\s+import).*)[\r\n]"
         code = re.sub(pattern, "", code, flags=re.MULTILINE)
 
         # Launch the user's script.

--- a/simpinkscr/simple_inkscape_scripting.py
+++ b/simpinkscr/simple_inkscape_scripting.py
@@ -3724,8 +3724,8 @@ from inkex.paths import curve, horz, move, quadratic, smooth, \
 
         # Remove an unnecessary import that may be introduced when
         # running from Visual Studio Code.
-        pattern = r"^(import (inkex|simpinkscr)|(from (inkex|simpinkscr) import.*))\r*\n*"
-        code = re.sub(pattern, "", code, flags=re.MULTILINE+re.IGNORECASE)
+        pattern = r"^[ \t]*(import\s+(inkex|simpinkscr).*|(from\s+(inkex|simpinkscr)\s+import).*)[\r\n]?"
+        code = re.sub(pattern, "", code, flags=re.MULTILINE)
 
         # Launch the user's script.
         try:


### PR DESCRIPTION
The line that I replaced was supposed to be removing the duplicate import that is required in a script if you want to develop in VSCode and have code completion, etc... It turns out the line didn't actually do anything because the replace method of a string doesn't change the string, so it needed to be reassigned to the variable, like code = code.replace(...

While fixing and testing this change, I realized that just a little more work and it could remove more combinations and iterations of the imports that might be used or suggested by VSCode, so I built and tested a regex that seems to do the trick with just about every situation I've come across while using VSCode and all the Python tools.

I'm open to comments and/or feedback, so please let me know if there are any suggestions!